### PR TITLE
Handle blank minimum and maximum in SwagerSchemaAnnotationStep

### DIFF
--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaAnnotationStep.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaAnnotationStep.kt
@@ -178,6 +178,7 @@ class SwaggerSchemaAnnotationStep {
         return property.annotations
             .filter { it.name == Schema::class.qualifiedName }
             .map { it.values["minimum"] as String }
+            .filter { it.isNotBlank() }
             .map { BigDecimal(it) }
             .firstOrNull()
     }
@@ -193,6 +194,7 @@ class SwaggerSchemaAnnotationStep {
         return property.annotations
             .filter { it.name == Schema::class.qualifiedName }
             .map { it.values["maximum"] as String }
+            .filter { it.isNotBlank() }
             .map { BigDecimal(it) }
             .firstOrNull()
     }

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/SwaggerAnnotationsTest.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/SwaggerAnnotationsTest.kt
@@ -13,6 +13,8 @@ import io.kotest.assertions.json.NumberFormat
 import io.kotest.assertions.json.PropertyOrder
 import io.kotest.assertions.json.TypeCoercion
 import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.StringSpec
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
@@ -78,6 +80,16 @@ class SwaggerAnnotationsTest : StringSpec({
         }
     }
 
+    "partially specified class" {
+        shouldNotThrowAny {
+            typeOf<PartiallySpecified>()
+                .processReflection()
+                .generateSwaggerSchema()
+                .handleSchemaAnnotations()
+                .compileInlining()
+        }
+    }
+
 }) {
 
     companion object {
@@ -121,5 +133,10 @@ class SwaggerAnnotationsTest : StringSpec({
         )
 
     }
+
+    private class PartiallySpecified(
+        @field:Schema(description = "Mysterious thing")
+        val x: String,
+    )
 
 }


### PR DESCRIPTION
`handleSchemaAnnotation()` crashes with a `NumberFormatException`-exception
if either `minimum` or `maximum` is not specified by the user in the `@Schema` annotation.

This PR adds unit test and fix. See issue https://github.com/SMILEY4/schema-kenerator/issues/8.