### PR TITLE
Process `@Default`-annotations from properties

### DIFF
--- a/schema-kenerator-jsonschema/src/main/kotlin/io/github/smiley4/schemakenerator/jsonschema/steps/JsonSchemaCoreAnnotationDefaultStep.kt
+++ b/schema-kenerator-jsonschema/src/main/kotlin/io/github/smiley4/schemakenerator/jsonschema/steps/JsonSchemaCoreAnnotationDefaultStep.kt
@@ -1,11 +1,12 @@
 package io.github.smiley4.schemakenerator.jsonschema.steps
 
 import io.github.smiley4.schemakenerator.core.annotations.Default
-import io.github.smiley4.schemakenerator.core.data.BaseTypeData
+import io.github.smiley4.schemakenerator.core.data.AnnotationData
 import io.github.smiley4.schemakenerator.core.data.Bundle
 import io.github.smiley4.schemakenerator.jsonschema.data.JsonSchema
 import io.github.smiley4.schemakenerator.jsonschema.jsonDsl.JsonObject
 import io.github.smiley4.schemakenerator.jsonschema.jsonDsl.JsonTextValue
+import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaAnnotationUtils.iterateProperties
 
 /**
  * Adds default values from [Default]-annotation
@@ -21,17 +22,21 @@ class JsonSchemaCoreAnnotationDefaultStep {
 
     private fun process(schema: JsonSchema) {
         if (schema.json is JsonObject && schema.json.properties["default"] == null) {
-            determineDefaults(schema.typeData)?.also { default ->
+            determineDefault(schema.typeData.annotations)?.also { default ->
                 schema.json.properties["default"] = JsonTextValue(default)
+            }
+        }
+        iterateProperties(schema) { prop, data ->
+            determineDefault(data.annotations)?.also { default ->
+                prop.properties["default"] = JsonTextValue(default)
             }
         }
     }
 
-    private fun determineDefaults(typeData: BaseTypeData): String? {
-        return typeData.annotations
+    private fun determineDefault(annotations: List<AnnotationData>): String? {
+        return annotations
             .filter { it.name == Default::class.qualifiedName }
             .map { it.values["default"] as String }
             .firstOrNull()
     }
-
 }

--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaCoreAnnotationDefaultStep.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaCoreAnnotationDefaultStep.kt
@@ -1,9 +1,10 @@
 package io.github.smiley4.schemakenerator.swagger.steps
 
 import io.github.smiley4.schemakenerator.core.annotations.Default
-import io.github.smiley4.schemakenerator.core.data.BaseTypeData
+import io.github.smiley4.schemakenerator.core.data.AnnotationData
 import io.github.smiley4.schemakenerator.core.data.Bundle
 import io.github.smiley4.schemakenerator.swagger.data.SwaggerSchema
+import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaAnnotationUtils.iterateProperties
 
 /**
  * Adds default values from [Default]-annotation
@@ -19,14 +20,19 @@ class SwaggerSchemaCoreAnnotationDefaultStep {
 
     private fun process(schema: SwaggerSchema) {
         if (schema.swagger.default == null) {
-            determineDefaults(schema.typeData)?.also { default ->
+            determineDefaults(schema.typeData.annotations)?.also { default ->
                 schema.swagger.setDefault(default)
+            }
+        }
+        iterateProperties(schema) { prop, data ->
+            determineDefaults(data.annotations)?.also { default ->
+                prop.setDefault(default)
             }
         }
     }
 
-    private fun determineDefaults(typeData: BaseTypeData): String? {
-        return typeData.annotations
+    private fun determineDefaults(annotations: List<AnnotationData>): String? {
+        return annotations
             .filter { it.name == Default::class.qualifiedName }
             .map { it.values["default"] as String }
             .firstOrNull()

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/ReflectionParser_JsonGenerator_Tests.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/ReflectionParser_JsonGenerator_Tests.kt
@@ -854,11 +854,25 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                 expectedResultInlining = """
                     {
                         "type": "object",
-                        "required": ["value"],
+                        "required": ["stringValue", "intValue"],
                         "properties": {
-                            "value": {
+                            "stringValue": {
                                 "type": "string",
-                                "description": "field description"
+                                "description": "String field description",
+                                "default": "A default String value",
+                                "examples": [
+                                    "An example of a String value"
+                                ]
+                            },
+                            "intValue": {
+                                "type": "integer",
+                                "default": "1111",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647,
+                                "description": "Int field description",
+                                "examples": [
+                                    "2222"
+                                ]
                             }
                         },
                         "title": "Annotated Class",
@@ -874,11 +888,25 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                 expectedResultReferencing = """
                     {
                         "type": "object",
-                        "required": ["value"],
+                        "required": ["stringValue", "intValue"],
                         "properties": {
-                            "value": {
+                            "stringValue": {
                                 "type": "string",
-                                "description": "field description"
+                                "description": "String field description",
+                                "default": "A default String value",
+                                "examples": [
+                                    "An example of a String value"
+                                ]
+                            },
+                            "intValue": {
+                                "type": "integer",
+                                "default": "1111",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647,
+                                "description": "Int field description",
+                                "examples": [
+                                    "2222"
+                                ]
                             }
                         },
                         "title": "Annotated Class",
@@ -897,13 +925,25 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                         "definitions": {
                             "io.github.smiley4.schemakenerator.test.models.reflection.CoreAnnotatedClass": {
                                 "type": "object",
-                                "required": [
-                                    "value"
-                                ],
+                                "required": ["stringValue", "intValue"],
                                 "properties": {
-                                    "value": {
+                                    "stringValue": {
                                         "type": "string",
-                                        "description": "field description"
+                                        "description": "String field description",
+                                        "default": "A default String value",
+                                        "examples": [
+                                            "An example of a String value"
+                                        ]
+                                    },
+                                    "intValue": {
+                                        "type": "integer",
+                                        "default": "1111",
+                                        "minimum": -2147483648,
+                                        "maximum": 2147483647,
+                                        "description": "Int field description",
+                                        "examples": [
+                                            "2222"
+                                        ]
                                     }
                                 },
                                 "title": "Annotated Class",

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/ReflectionParser_SwaggerGenerator_Tests.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/ReflectionParser_SwaggerGenerator_Tests.kt
@@ -1105,14 +1105,29 @@ class ReflectionParser_SwaggerGenerator_Tests : FunSpec({
                         "schema": {
                             "title": "Annotated Class",
                             "required": [
-                                "value"
+                                "stringValue",
+                                "intValue"
                             ],
                             "type": "object",
                             "properties": {
-                                "value": {
+                                "stringValue": {
                                     "type": "string",
-                                    "description": "field description",
-                                    "exampleSetFlag": false
+                                    "description": "String field description",
+                                    "default": "A default String value",
+                                    "exampleSetFlag": false,
+                                    "examples": [
+                                        "An example of a String value"
+                                    ]
+                                },
+                                "intValue": {
+                                    "type": "integer",
+                                    "format": "int32",
+                                    "description": "Int field description",
+                                    "default": "1111",
+                                    "exampleSetFlag": false,
+                                    "examples": [
+                                        "2222"
+                                    ]
                                 }
                             },
                             "description": "some description",
@@ -1132,14 +1147,29 @@ class ReflectionParser_SwaggerGenerator_Tests : FunSpec({
                         "schema": {
                             "title": "Annotated Class",
                             "required": [
-                                "value"
+                                "stringValue",
+                                "intValue"
                             ],
                             "type": "object",
                             "properties": {
-                                "value": {
+                                "stringValue": {
                                     "type": "string",
-                                    "description": "field description",
-                                    "exampleSetFlag": false
+                                    "description": "String field description",
+                                    "default": "A default String value",
+                                    "exampleSetFlag": false,
+                                    "examples": [
+                                        "An example of a String value"
+                                    ]
+                                },
+                                "intValue": {
+                                    "type": "integer",
+                                    "format": "int32",
+                                    "description": "Int field description",
+                                    "default": "1111",
+                                    "exampleSetFlag": false,
+                                    "examples": [
+                                        "2222"
+                                    ]
                                 }
                             },
                             "description": "some description",
@@ -1164,14 +1194,29 @@ class ReflectionParser_SwaggerGenerator_Tests : FunSpec({
                             "io.github.smiley4.schemakenerator.test.models.reflection.CoreAnnotatedClass": {
                                 "title": "Annotated Class",
                                 "required": [
-                                    "value"
+                                    "stringValue",
+                                    "intValue"
                                 ],
                                 "type": "object",
                                 "properties": {
-                                    "value": {
+                                    "stringValue": {
                                         "type": "string",
-                                        "description": "field description",
-                                        "exampleSetFlag": false
+                                        "description": "String field description",
+                                        "default": "A default String value",
+                                        "exampleSetFlag": false,
+                                        "examples": [
+                                            "An example of a String value"
+                                        ]
+                                    },
+                                    "intValue": {
+                                        "type": "integer",
+                                        "format": "int32",
+                                        "description": "Int field description",
+                                        "default": "1111",
+                                        "exampleSetFlag": false,
+                                        "examples": [
+                                            "2222"
+                                        ]
                                     }
                                 },
                                 "description": "some description",

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/models/reflection/CoreAnnotatedClass.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/models/reflection/CoreAnnotatedClass.kt
@@ -14,6 +14,13 @@ import io.github.smiley4.schemakenerator.core.annotations.Title
 @Example("example 2")
 @Deprecated
 class CoreAnnotatedClass(
-    @Description("field description")
-    val value: String
+    @Description("String field description")
+    @Default("A default String value")
+    @Example("An example of a String value")
+    val stringValue: String,
+
+    @Description("Int field description")
+    @Default("1111")
+    @Example("2222")
+    val intValue: Int,
 )


### PR DESCRIPTION
This adds processing of `@Default`-annotations placed on properties when generating Json-schemas and Swagger-schemas.

Only the test with reflection-parsing is updated, as the kotlinx-parser does not pick up annotations on properties (see [existing unit test here](https://github.com/SMILEY4/schema-kenerator/blob/ae98c640a951255e7e49f2eac22761fde0a7506f/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/KotlinxSerializationParser_SwaggerGenerator_Tests.kt#L946) where the `@Description` from the property is not in the output). But that's a separate issue I think.