### PR TITLE
KotlinxSerialization: extract annotations from properties

### DIFF
--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/steps/KotlinxSerializationTypeProcessingStep.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/steps/KotlinxSerializationTypeProcessingStep.kt
@@ -24,13 +24,11 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.SerialKind
 import kotlinx.serialization.descriptors.StructureKind
-import kotlinx.serialization.descriptors.buildSerialDescriptor
 import kotlinx.serialization.descriptors.elementDescriptors
 import kotlinx.serialization.descriptors.elementNames
 import kotlinx.serialization.serializerOrNull
 import java.lang.reflect.Modifier
 import kotlin.reflect.KClass
-import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty
 import kotlin.reflect.KType
 import kotlin.reflect.jvm.javaField
@@ -279,6 +277,7 @@ class KotlinxSerializationTypeProcessingStep(
                                 optional = descriptor.isElementOptional(i),
                                 kind = PropertyType.PROPERTY,
                                 visibility = Visibility.PUBLIC,
+                                annotations = parseAnnotations(descriptor.getElementAnnotations(i)),
                             )
                         )
                     }
@@ -347,7 +346,11 @@ class KotlinxSerializationTypeProcessingStep(
     // ====== ANNOTATION ===============================================
 
     private fun parseAnnotations(descriptor: SerialDescriptor): MutableList<AnnotationData>{
-        return unwrapAnnotations(descriptor.annotations).map { parseAnnotation(it) }.toMutableList()
+        return parseAnnotations(descriptor.annotations)
+    }
+
+    private fun parseAnnotations(annotations: List<Annotation>): MutableList<AnnotationData>{
+        return unwrapAnnotations(annotations).map { parseAnnotation(it) }.toMutableList()
     }
 
     private fun unwrapAnnotations(annotations: List<Annotation>): List<Annotation> {

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/KotlinxSerializationParser_SwaggerGenerator_Tests.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/KotlinxSerializationParser_SwaggerGenerator_Tests.kt
@@ -945,6 +945,7 @@ class KotlinxSerializationParser_SwaggerGenerator_Tests : FunSpec({
                         "properties": {
                             "value": {
                                 "type": "string",
+                                "description": "field description",
                                 "exampleSetFlag": false
                             }
                         },
@@ -969,6 +970,7 @@ class KotlinxSerializationParser_SwaggerGenerator_Tests : FunSpec({
                             "properties": {
                                 "value": {
                                     "type": "string",
+                                    "description": "field description",
                                     "exampleSetFlag": false
                                 }
                             },
@@ -1000,6 +1002,7 @@ class KotlinxSerializationParser_SwaggerGenerator_Tests : FunSpec({
                                 "properties": {
                                     "value": {
                                         "type": "string",
+                                        "description": "field description",
                                         "exampleSetFlag": false
                                     }
                                 },


### PR DESCRIPTION
As mentioned in PR  https://github.com/SMILEY4/schema-kenerator/pull/11, I didn't update the test using kotlinx-serialization, because annotations on properties were not extracted. This seems like a way to do this.