### PR TITLE
GH-22

### DIFF
--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaAnnotationUtils.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaAnnotationUtils.kt
@@ -36,7 +36,7 @@ object SwaggerSchemaAnnotationUtils {
             }
             keysToRemove.forEach {
                 schema.swagger.properties.remove(it)
-                schema.swagger.required.remove(it)
+                schema.swagger.required?.remove(it)
             }
         }
     }

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/SwaggerAnnotationsTest.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/SwaggerAnnotationsTest.kt
@@ -13,7 +13,6 @@ import io.kotest.assertions.json.NumberFormat
 import io.kotest.assertions.json.PropertyOrder
 import io.kotest.assertions.json.TypeCoercion
 import io.kotest.assertions.json.shouldEqualJson
-import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.StringSpec
 import io.swagger.v3.oas.annotations.media.ArraySchema
@@ -90,6 +89,16 @@ class SwaggerAnnotationsTest : StringSpec({
         }
     }
 
+    "hidden fields with no required fields" {
+        shouldNotThrowAny {
+            typeOf<AllOptionalFields>()
+                .processReflection()
+                .generateSwaggerSchema()
+                .handleSchemaAnnotations()
+                .compileInlining()
+        }
+    }
+
 }) {
 
     companion object {
@@ -137,6 +146,15 @@ class SwaggerAnnotationsTest : StringSpec({
     private class PartiallySpecified(
         @field:Schema(description = "Mysterious thing")
         val x: String,
+    )
+
+    private class AllOptionalFields(
+        @field:Schema(description = "The first field")
+        val firstField: String?,
+        @field:Schema(hidden = true)
+        val secondField: Int?,
+        @field:Schema(hidden = true)
+        val thirdField: Boolean?
     )
 
 }


### PR DESCRIPTION
Add a null check when trying to remove properties from the Swagger `Schema` List of required properties. (As the required properties will be null, rather than an empty list, if there are no required properties.)