### PR TITLE
Fix NPE

### DIFF
--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/SwaggerAnnotationsTest.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/SwaggerAnnotationsTest.kt
@@ -223,6 +223,249 @@ class SwaggerAnnotationsTest : StringSpec({
             }
     }
 
+    "javax and jakarta required annotations for all null properties" {
+        var result = typeOf<NotNullWithAllNullProperties>()
+            .processReflection()
+            .generateSwaggerSchema()
+            .handleJavaxValidationAnnotations()
+            .compileInlining()
+        jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(result.swagger)
+            .shouldEqualJson {
+                propertyOrder = PropertyOrder.Lenient
+                arrayOrder = ArrayOrder.Lenient
+                fieldComparison = FieldComparison.Strict
+                numberFormat = NumberFormat.Lenient
+                typeCoercion = TypeCoercion.Disabled
+                """
+                {
+                  "required": [
+                    "requiredProperty"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "requiredProperty": {
+                      "type": "string",
+                      "exampleSetFlag": false
+                    }
+                  },
+                  "exampleSetFlag": false
+                }
+            """.trimIndent()
+            }
+        result = typeOf<NotEmptyWithAllNullProperties>()
+            .processReflection()
+            .generateSwaggerSchema()
+            .handleJavaxValidationAnnotations()
+            .compileInlining()
+        jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(result.swagger)
+            .shouldEqualJson {
+                propertyOrder = PropertyOrder.Lenient
+                arrayOrder = ArrayOrder.Lenient
+                fieldComparison = FieldComparison.Strict
+                numberFormat = NumberFormat.Lenient
+                typeCoercion = TypeCoercion.Disabled
+                """
+                {
+                  "required": [
+                    "requiredProperty"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "requiredProperty": {
+                      "type": "string",
+                      "exampleSetFlag": false
+                    }
+                  },
+                  "exampleSetFlag": false
+                }
+            """.trimIndent()
+            }
+        result = typeOf<NotBlankWithAllNullProperties>()
+            .processReflection()
+            .generateSwaggerSchema()
+            .handleJavaxValidationAnnotations()
+            .compileInlining()
+        jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(result.swagger)
+            .shouldEqualJson {
+                propertyOrder = PropertyOrder.Lenient
+                arrayOrder = ArrayOrder.Lenient
+                fieldComparison = FieldComparison.Strict
+                numberFormat = NumberFormat.Lenient
+                typeCoercion = TypeCoercion.Disabled
+                """
+                {
+                  "required": [
+                    "requiredProperty"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "requiredProperty": {
+                      "type": "string",
+                      "exampleSetFlag": false
+                    }
+                  },
+                  "exampleSetFlag": false
+                }
+            """.trimIndent()
+            }
+        result = typeOf<JakartaNotNullWithAllNullProperties>()
+            .processReflection()
+            .generateSwaggerSchema()
+            .handleJakartaValidationAnnotations()
+            .compileInlining()
+        jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(result.swagger)
+            .shouldEqualJson {
+                propertyOrder = PropertyOrder.Lenient
+                arrayOrder = ArrayOrder.Lenient
+                fieldComparison = FieldComparison.Strict
+                numberFormat = NumberFormat.Lenient
+                typeCoercion = TypeCoercion.Disabled
+                """
+                {
+                  "required": [
+                    "requiredProperty"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "requiredProperty": {
+                      "type": "string",
+                      "exampleSetFlag": false
+                    }
+                  },
+                  "exampleSetFlag": false
+                }
+            """.trimIndent()
+            }
+        result = typeOf<JakartaNotEmptyWithAllNullProperties>()
+            .processReflection()
+            .generateSwaggerSchema()
+            .handleJakartaValidationAnnotations()
+            .compileInlining()
+        jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(result.swagger)
+            .shouldEqualJson {
+                propertyOrder = PropertyOrder.Lenient
+                arrayOrder = ArrayOrder.Lenient
+                fieldComparison = FieldComparison.Strict
+                numberFormat = NumberFormat.Lenient
+                typeCoercion = TypeCoercion.Disabled
+                """
+                {
+                  "required": [
+                    "requiredProperty"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "requiredProperty": {
+                      "type": "string",
+                      "exampleSetFlag": false
+                    }
+                  },
+                  "exampleSetFlag": false
+                }
+            """.trimIndent()
+            }
+        result = typeOf<JakartaNotBlankWithAllNullProperties>()
+            .processReflection()
+            .generateSwaggerSchema()
+            .handleJakartaValidationAnnotations()
+            .compileInlining()
+        jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(result.swagger)
+            .shouldEqualJson {
+                propertyOrder = PropertyOrder.Lenient
+                arrayOrder = ArrayOrder.Lenient
+                fieldComparison = FieldComparison.Strict
+                numberFormat = NumberFormat.Lenient
+                typeCoercion = TypeCoercion.Disabled
+                """
+                {
+                  "required": [
+                    "requiredProperty"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "requiredProperty": {
+                      "type": "string",
+                      "exampleSetFlag": false
+                    }
+                  },
+                  "exampleSetFlag": false
+                }
+            """.trimIndent()
+            }
+        result = typeOf<AllRequiredValidations>()
+            .processReflection()
+            .generateSwaggerSchema()
+            .handleJavaxValidationAnnotations()
+            .compileInlining()
+        jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(result.swagger)
+            .shouldEqualJson {
+                propertyOrder = PropertyOrder.Lenient
+                arrayOrder = ArrayOrder.Lenient
+                fieldComparison = FieldComparison.Strict
+                numberFormat = NumberFormat.Lenient
+                typeCoercion = TypeCoercion.Disabled
+                """
+                {
+                  "required": [
+                    "requiredProperty"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "requiredProperty": {
+                      "type": "string",
+                      "exampleSetFlag": false
+                    }
+                  },
+                  "exampleSetFlag": false
+                }
+            """.trimIndent()
+            }
+        result = typeOf<JakartaAllRequiredValidations>()
+            .processReflection()
+            .generateSwaggerSchema()
+            .handleJakartaValidationAnnotations()
+            .compileInlining()
+        jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            .writerWithDefaultPrettyPrinter()
+            .writeValueAsString(result.swagger)
+            .shouldEqualJson {
+                propertyOrder = PropertyOrder.Lenient
+                arrayOrder = ArrayOrder.Lenient
+                fieldComparison = FieldComparison.Strict
+                numberFormat = NumberFormat.Lenient
+                typeCoercion = TypeCoercion.Disabled
+                """
+                {
+                  "required": [
+                    "requiredProperty"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "requiredProperty": {
+                      "type": "string",
+                      "exampleSetFlag": false
+                    }
+                  },
+                  "exampleSetFlag": false
+                }
+            """.trimIndent()
+            }
+    }
+
 }) {
 
     companion object {
@@ -307,6 +550,50 @@ class SwaggerAnnotationsTest : StringSpec({
         val mustNotBeBlank: String?,
         @field:jakarta.validation.constraints.Size(min = 4, max = 95)
         val hasSize: String
+    )
+
+    private class NotNullWithAllNullProperties(
+        @field:NotNull
+        val requiredProperty: String?
+    )
+
+    private class NotEmptyWithAllNullProperties(
+        @field:NotEmpty
+        val requiredProperty: String?
+    )
+
+    private class NotBlankWithAllNullProperties(
+        @field:NotBlank
+        val requiredProperty: String?
+    )
+
+    private class JakartaNotNullWithAllNullProperties(
+        @field:jakarta.validation.constraints.NotNull
+        val requiredProperty: String?
+    )
+
+    private class JakartaNotEmptyWithAllNullProperties(
+        @field:jakarta.validation.constraints.NotEmpty
+        val requiredProperty: String?
+    )
+
+    private class JakartaNotBlankWithAllNullProperties(
+        @field:jakarta.validation.constraints.NotBlank
+        val requiredProperty: String?
+    )
+
+    private class AllRequiredValidations(
+        @field:NotNull
+        @field:NotEmpty
+        @field:NotBlank
+        val requiredProperty: String?
+    )
+
+    private class JakartaAllRequiredValidations(
+        @field:jakarta.validation.constraints.NotNull
+        @field:jakarta.validation.constraints.NotEmpty
+        @field:jakarta.validation.constraints.NotBlank
+        val requiredProperty: String?
     )
 
 }

--- a/schema-kenerator-validation-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/validation/swagger/steps/SwaggerJakartaValidationAnnotationStep.kt
+++ b/schema-kenerator-validation-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/validation/swagger/steps/SwaggerJakartaValidationAnnotationStep.kt
@@ -6,12 +6,7 @@ import io.github.smiley4.schemakenerator.core.data.PropertyData
 import io.github.smiley4.schemakenerator.swagger.data.SwaggerSchema
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaAnnotationUtils
 import io.swagger.v3.oas.models.media.Schema
-import jakarta.validation.constraints.Max
-import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotEmpty
-import jakarta.validation.constraints.NotNull
-import jakarta.validation.constraints.Size
+import jakarta.validation.constraints.*
 import java.math.BigDecimal
 
 /**
@@ -35,7 +30,7 @@ class SwaggerJakartaValidationAnnotationStep {
     private fun process(schema: SwaggerSchema) {
         SwaggerSchemaAnnotationUtils.iterateProperties(schema) { prop, data ->
             getNotNull(data)?.also { setRequiredNotNull(schema.swagger, data.name) }
-            getNotEmpty(data)?.also  { setRequiredNotNull(schema.swagger, data.name) }
+            getNotEmpty(data)?.also { setRequiredNotNull(schema.swagger, data.name) }
             getNotBlank(data)?.also { setRequiredNotNull(schema.swagger, data.name) }
             getSize(data)?.also {
                 val min = it.values["min"] as Int
@@ -84,16 +79,16 @@ class SwaggerJakartaValidationAnnotationStep {
     }
 
     private fun setRequiredNotNull(swagger: Schema<*>, name: String) {
-        if(!swagger.required.contains(name)) {
+        if (swagger.required?.contains(name) != true) {
             swagger.addRequiredItem(name)
         }
         swagger.properties[name]?.also { prop ->
-            if(prop.nullable == true) {
+            if (prop.nullable == true) {
                 prop.nullable = false
             }
-            if(prop.types != null && prop.types.contains("null")) {
+            if (prop.types != null && prop.types.contains("null")) {
                 prop.types.remove("null")
-                if(prop.types.size == 1) {
+                if (prop.types.size == 1) {
                     prop.type = prop.types.first()
                     prop.types.clear()
                 }

--- a/schema-kenerator-validation-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/validation/swagger/steps/SwaggerJavaxValidationAnnotationStep.kt
+++ b/schema-kenerator-validation-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/validation/swagger/steps/SwaggerJavaxValidationAnnotationStep.kt
@@ -30,7 +30,7 @@ class SwaggerJavaxValidationAnnotationStep {
     private fun process(schema: SwaggerSchema) {
         SwaggerSchemaAnnotationUtils.iterateProperties(schema) { prop, data ->
             getNotNull(data)?.also { setRequiredNotNull(schema.swagger, data.name) }
-            getNotEmpty(data)?.also  { setRequiredNotNull(schema.swagger, data.name) }
+            getNotEmpty(data)?.also { setRequiredNotNull(schema.swagger, data.name) }
             getNotBlank(data)?.also { setRequiredNotNull(schema.swagger, data.name) }
             getSize(data)?.also {
                 val min = it.values["min"] as Int
@@ -79,16 +79,16 @@ class SwaggerJavaxValidationAnnotationStep {
     }
 
     private fun setRequiredNotNull(swagger: Schema<*>, name: String) {
-        if(!swagger.required.contains(name)) {
+        if (swagger.required?.contains(name) != true) {
             swagger.addRequiredItem(name)
         }
         swagger.properties[name]?.also { prop ->
-            if(prop.nullable == true) {
+            if (prop.nullable == true) {
                 prop.nullable = false
             }
-            if(prop.types != null && prop.types.contains("null")) {
+            if (prop.types != null && prop.types.contains("null")) {
                 prop.types.remove("null")
-                if(prop.types.size == 1) {
+                if (prop.types.size == 1) {
                     prop.type = prop.types.first()
                     prop.types.clear()
                 }


### PR DESCRIPTION
Fix NPE when checking for existing required properties while processing validation annotations.

Got this error when trying to use it in my code:
java.lang.NullPointerException: Cannot invoke "java.util.List.contains(Object)" because the return value of "io.swagger.v3.oas.models.media.Schema.getRequired()" is null
	at io.github.smiley4.schemakenerator.validation.swagger.steps.SwaggerJakartaValidationAnnotationStep.setRequiredNotNull(SwaggerJakartaValidationAnnotationStep.kt:87)