### PR TITLE
handle documented cases in Schema annotation

### DIFF
--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaAnnotationStep.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaAnnotationStep.kt
@@ -70,8 +70,10 @@ class SwaggerSchemaAnnotationStep {
                     }
                 }
             }
-            getMinLength(data)?.also { prop.minLength = it }
-            getMaxLength(data)?.also { prop.maxLength = it }
+            if (schema.swagger.type == "string") {
+                getMinLength(data)?.also { prop.minLength = it }
+                getMaxLength(data)?.also { prop.maxLength = it }
+            }
             getFormat(data)?.also { prop.format = it }
             getMinimum(data)?.also { prop.minimum = it }
             getMaximum(data)?.also { prop.maximum = it }
@@ -157,21 +159,21 @@ class SwaggerSchemaAnnotationStep {
         return property.annotations
             .filter { it.name == Schema::class.qualifiedName }
             .map { it.values["minLength"] as Int }
-            .firstOrNull()
+            .firstOrNull { it >= 0 }
     }
 
     private fun getMaxLength(property: PropertyData): Int? {
         return property.annotations
             .filter { it.name == Schema::class.qualifiedName }
             .map { it.values["maxLength"] as Int }
-            .firstOrNull()
+            .firstOrNull { it >= 0 }
     }
 
     private fun getFormat(property: PropertyData): String? {
         return property.annotations
             .filter { it.name == Schema::class.qualifiedName }
             .map { it.values["format"] as String }
-            .firstOrNull()
+            .firstOrNull { it.isNotBlank() }
     }
 
     private fun getMinimum(property: PropertyData): BigDecimal? {

--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaAnnotationStep.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaAnnotationStep.kt
@@ -70,10 +70,8 @@ class SwaggerSchemaAnnotationStep {
                     }
                 }
             }
-            if (schema.swagger.type == "string") {
-                getMinLength(data)?.also { prop.minLength = it }
-                getMaxLength(data)?.also { prop.maxLength = it }
-            }
+            getMinLength(data)?.also { prop.minLength = it }
+            getMaxLength(data)?.also { prop.maxLength = it }
             getFormat(data)?.also { prop.format = it }
             getMinimum(data)?.also { prop.minimum = it }
             getMaximum(data)?.also { prop.maximum = it }


### PR DESCRIPTION
- `minLength` and `maxLength` are ignored if the value is below 0
- `format` is included only if it's not blank

Closes #29 