### PR TITLE
Add support for example property on Schema annotation.

### DIFF
--- a/schema-kenerator-swagger/README.md
+++ b/schema-kenerator-swagger/README.md
@@ -23,6 +23,7 @@ dependencies {
 |--------------------------------------------------|-----------------------------------------------------|-----------------------------|
 | `@Schema(title=...)` on types & properties       | Sets the `title`-property of the schema.            | `handleSchemaAnnotations()` |
 | `@Schema(description=...)` on types & properties | Sets the `description`-property of the schema.      | `handleSchemaAnnotations()` |
+| `@Schema(example=...)` on types & properties     | Sets the `example`-property of the schema.          | `handleSchemaAnnotations()` |
 | `@Schema(name=...)` on properties                | Sets the `name`-property of the schema.             | `handleSchemaAnnotations()` |
 | `@Schema(hidden=...)` on properties              | Sets the `hidden`-property of the schema.           | `handleSchemaAnnotations()` |
 | `@Schema(allowableValues=...)` on properties     | Sets the `allowableValues`-property of the schema.  | `handleSchemaAnnotations()` |

--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaAnnotationStep.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaAnnotationStep.kt
@@ -18,6 +18,7 @@ import java.math.BigDecimal
  *      - name
  *      - title
  *      - description
+ *      - example
  *      - hidden
  *      - allowableValues
  *      - defaultValue
@@ -45,6 +46,7 @@ class SwaggerSchemaAnnotationStep : AbstractSwaggerSchemaStep() {
             val mergedAnnotations = propData.annotations + propTypeData.annotations
             getTitle(mergedAnnotations)?.also { prop.title = it }
             getDescription(mergedAnnotations)?.also { prop.description = it }
+            getExample(mergedAnnotations)?.also { prop.example = it }
             getName(mergedAnnotations)?.also { prop.name = it }
             getAllowableValues(mergedAnnotations)?.onEach { entry ->
                 @Suppress("UNCHECKED_CAST")
@@ -79,10 +81,19 @@ class SwaggerSchemaAnnotationStep : AbstractSwaggerSchemaStep() {
             .map { it.ifBlank { null } }
             .firstOrNull()
     }
+
     private fun getDescription(annotations: Collection<AnnotationData>): String? {
         return annotations
             .filter { it.name == Schema::class.qualifiedName }
             .map { it.values["description"] as String }
+            .map { it.ifBlank { null } }
+            .firstOrNull()
+    }
+
+    private fun getExample(annotations: Collection<AnnotationData>): String? {
+        return annotations
+            .filter { it.name == Schema::class.qualifiedName }
+            .map { it.values["example"] as String }
             .map { it.ifBlank { null } }
             .firstOrNull()
     }

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/SwaggerAnnotationsTest.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/SwaggerAnnotationsTest.kt
@@ -62,9 +62,10 @@ class SwaggerAnnotationsTest : StringSpec({
                       "minLength": 1,
                       "types": ["integer"],
                       "description": "some value",
+                      "example": "5",
                       "format": "single-digit",
                       "readOnly": true,
-                      "exampleSetFlag": false,
+                      "exampleSetFlag": true,
                       "enum": ["1","2","3","4"],
                       "default": "1"
                     },
@@ -479,6 +480,7 @@ class SwaggerAnnotationsTest : StringSpec({
 
             @field:Schema(
                 description = "some value",
+                example = "5",
                 title = "Some Value",
                 name = "someValue",
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED,


### PR DESCRIPTION
As the title says, I use the `example` property in the `Schema` annotation, and I want it to be included in the schema output. :)