### PR TITLE
fix: rename `Default#default` -> `Default#value`

### DIFF
--- a/schema-kenerator-core/src/main/kotlin/io/github/smiley4/schemakenerator/core/annotations/Default.kt
+++ b/schema-kenerator-core/src/main/kotlin/io/github/smiley4/schemakenerator/core/annotations/Default.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.SerialInfo
 
 /**
  * Specifies a default value for the annotated object.
+ * @param value The default value for the annotated object.
  */
 @OptIn(ExperimentalSerializationApi::class)
 @Target(
@@ -15,4 +16,4 @@ import kotlinx.serialization.SerialInfo
 )
 @SerialInfo
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Default(val default: String)
+annotation class Default(val value: String)

--- a/schema-kenerator-jsonschema/src/main/kotlin/io/github/smiley4/schemakenerator/jsonschema/steps/JsonSchemaCoreAnnotationDefaultStep.kt
+++ b/schema-kenerator-jsonschema/src/main/kotlin/io/github/smiley4/schemakenerator/jsonschema/steps/JsonSchemaCoreAnnotationDefaultStep.kt
@@ -30,7 +30,7 @@ class JsonSchemaCoreAnnotationDefaultStep : AbstractJsonSchemaStep() {
     private fun determineDefault(annotations: List<AnnotationData>): String? {
         return annotations
             .filter { it.name == Default::class.qualifiedName }
-            .map { it.values["default"] as String }
+            .map { it.values["value"] as String }
             .firstOrNull()
     }
 }

--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaCoreAnnotationDefaultStep.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaCoreAnnotationDefaultStep.kt
@@ -14,21 +14,21 @@ class SwaggerSchemaCoreAnnotationDefaultStep : AbstractSwaggerSchemaStep() {
 
     override fun process(schema: SwaggerSchema, typeDataMap: Map<TypeId, BaseTypeData>) {
         if (schema.swagger.default == null) {
-            determineDefaults(schema.typeData.annotations)?.also { default ->
+            determineDefault(schema.typeData.annotations)?.also { default ->
                 schema.swagger.setDefault(default)
             }
         }
         iterateProperties(schema, typeDataMap) { prop, propData, propTypeData ->
-            determineDefaults(propData.annotations + propTypeData.annotations)?.also { default ->
+            determineDefault(propData.annotations + propTypeData.annotations)?.also { default ->
                 prop.setDefault(default)
             }
         }
     }
 
-    private fun determineDefaults(annotations: Collection<AnnotationData>): String? {
+    private fun determineDefault(annotations: Collection<AnnotationData>): String? {
         return annotations
             .filter { it.name == Default::class.qualifiedName }
-            .map { it.values["default"] as String }
+            .map { it.values["value"] as String }
             .firstOrNull()
     }
 


### PR DESCRIPTION
`default` is a restricted keyword in java, stubs generated from apt/kapt strip this value due to the naming conflict

Fixes #34 