### PR TITLE
feat: add `@Format` core annotation for Swagger and Json schema

### DIFF
--- a/schema-kenerator-core/README.md
+++ b/schema-kenerator-core/README.md
@@ -20,6 +20,9 @@ dependencies {
 | `@Deprecated`  | Specify whether the annotated type or property should be marked as deprecated. | `handleCoreAnnotations` (jsonschema, swagger) |
 | `@Example`     | Provide example values for the annotated type or property                      | `handleCoreAnnotations` (jsonschema, swagger) |
 | `@Default`     | Specify a default value for the annotated type or property                     | `handleCoreAnnotations` (jsonschema, swagger) |
+| `@Optional`    | Specify that the annotated type or property is optional.                       | `handleCoreAnnotations` (jsonschema, swagger) |
+| `@Required`    | Specify that the annotated type or property is required.                       | `handleCoreAnnotations` (jsonschema, swagger) |
+| `@Format`      | Specify the schema format of the annotated type or property.                   | `handleCoreAnnotations` (jsonschema, swagger) |
 
 ## Steps
 

--- a/schema-kenerator-core/src/main/kotlin/io/github/smiley4/schemakenerator/core/annotations/Format.kt
+++ b/schema-kenerator-core/src/main/kotlin/io/github/smiley4/schemakenerator/core/annotations/Format.kt
@@ -1,0 +1,19 @@
+package io.github.smiley4.schemakenerator.core.annotations
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialInfo
+
+/**
+ * Specifies the format of a schema for the annotated object.
+ * @param format the schema's format
+ */
+@OptIn(ExperimentalSerializationApi::class)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.FUNCTION
+)
+@SerialInfo
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Format(val format: String)

--- a/schema-kenerator-jsonschema/src/main/kotlin/io/github/smiley4/schemakenerator/jsonschema/steps.kt
+++ b/schema-kenerator-jsonschema/src/main/kotlin/io/github/smiley4/schemakenerator/jsonschema/steps.kt
@@ -17,6 +17,7 @@ import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotati
 import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotationDeprecatedStep
 import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotationDescriptionStep
 import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotationExamplesStep
+import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotationFormatStep
 import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotationOptionalAndRequiredStep
 import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotationTitleStep
 import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCustomizeStep
@@ -87,7 +88,8 @@ fun Bundle<JsonSchema>.withTitle(builder: (type: BaseTypeData, types: Map<TypeId
 
 /**
  * See [JsonSchemaCoreAnnotationDefaultStep], [JsonSchemaCoreAnnotationDeprecatedStep], [JsonSchemaCoreAnnotationDescriptionStep],
- * [JsonSchemaCoreAnnotationExamplesStep], [JsonSchemaCoreAnnotationTitleStep], [JsonSchemaCoreAnnotationOptionalAndRequiredStep]
+ * [JsonSchemaCoreAnnotationExamplesStep], [JsonSchemaCoreAnnotationTitleStep], [JsonSchemaCoreAnnotationOptionalAndRequiredStep],
+ * [JsonSchemaCoreAnnotationFormatStep]
  */
 fun Bundle<JsonSchema>.handleCoreAnnotations(): Bundle<JsonSchema> {
     return this
@@ -97,6 +99,7 @@ fun Bundle<JsonSchema>.handleCoreAnnotations(): Bundle<JsonSchema> {
         .let { JsonSchemaCoreAnnotationDescriptionStep().process(this) }
         .let { JsonSchemaCoreAnnotationExamplesStep().process(this) }
         .let { JsonSchemaCoreAnnotationTitleStep().process(this) }
+        .let { JsonSchemaCoreAnnotationFormatStep().process(this) }
 }
 
 

--- a/schema-kenerator-jsonschema/src/main/kotlin/io/github/smiley4/schemakenerator/jsonschema/steps/JsonSchemaCoreAnnotationFormatStep.kt
+++ b/schema-kenerator-jsonschema/src/main/kotlin/io/github/smiley4/schemakenerator/jsonschema/steps/JsonSchemaCoreAnnotationFormatStep.kt
@@ -1,0 +1,36 @@
+package io.github.smiley4.schemakenerator.jsonschema.steps
+
+import io.github.smiley4.schemakenerator.core.annotations.Format
+import io.github.smiley4.schemakenerator.core.data.AnnotationData
+import io.github.smiley4.schemakenerator.core.data.BaseTypeData
+import io.github.smiley4.schemakenerator.core.data.TypeId
+import io.github.smiley4.schemakenerator.jsonschema.data.JsonSchema
+import io.github.smiley4.schemakenerator.jsonschema.jsonDsl.JsonObject
+import io.github.smiley4.schemakenerator.jsonschema.jsonDsl.JsonTextValue
+import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaAnnotationUtils.iterateProperties
+
+/**
+ * Adds format values from [Format]-annotation
+ */
+class JsonSchemaCoreAnnotationFormatStep : AbstractJsonSchemaStep() {
+
+    override fun process(schema: JsonSchema, typeDataMap: Map<TypeId, BaseTypeData>) {
+        if (schema.json is JsonObject && schema.json.properties["format"] == null) {
+            determineFormat(schema.typeData.annotations)?.also { format ->
+                schema.json.properties["format"] = JsonTextValue(format)
+            }
+        }
+        iterateProperties(schema, typeDataMap) { prop, propData, propTypeData ->
+            determineFormat(propData.annotations + propTypeData.annotations)?.also { format ->
+                prop.properties["format"] = JsonTextValue(format)
+            }
+        }
+    }
+
+    private fun determineFormat(annotations: List<AnnotationData>): String? {
+        return annotations
+            .filter { it.name == Format::class.qualifiedName }
+            .map { it.values["format"] as String }
+            .firstOrNull()
+    }
+}

--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps.kt
@@ -18,6 +18,7 @@ import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotati
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationDeprecatedStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationDescriptionStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationExamplesStep
+import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationFormatStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationOptionalAndRequiredStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationTitleStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCustomizeStep
@@ -91,7 +92,8 @@ fun Bundle<SwaggerSchema>.withTitle(builder: (type: BaseTypeData, types: Map<Typ
 
 /**
  * See [SwaggerSchemaCoreAnnotationDefaultStep], [SwaggerSchemaCoreAnnotationDeprecatedStep], [SwaggerSchemaCoreAnnotationDescriptionStep],
- * [SwaggerSchemaCoreAnnotationExamplesStep], [SwaggerSchemaCoreAnnotationTitleStep], [SwaggerSchemaCoreAnnotationOptionalAndRequiredStep]
+ * [SwaggerSchemaCoreAnnotationExamplesStep], [SwaggerSchemaCoreAnnotationTitleStep], [SwaggerSchemaCoreAnnotationOptionalAndRequiredStep],
+ * [SwaggerSchemaCoreAnnotationFormatStep]
  */
 fun Bundle<SwaggerSchema>.handleCoreAnnotations(): Bundle<SwaggerSchema> {
     return this
@@ -101,6 +103,7 @@ fun Bundle<SwaggerSchema>.handleCoreAnnotations(): Bundle<SwaggerSchema> {
         .let { SwaggerSchemaCoreAnnotationDescriptionStep().process(this) }
         .let { SwaggerSchemaCoreAnnotationExamplesStep().process(this) }
         .let { SwaggerSchemaCoreAnnotationTitleStep().process(this) }
+        .let { SwaggerSchemaCoreAnnotationFormatStep().process(this) }
 }
 
 

--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaCoreAnnotationFormatStep.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/steps/SwaggerSchemaCoreAnnotationFormatStep.kt
@@ -1,0 +1,35 @@
+package io.github.smiley4.schemakenerator.swagger.steps
+
+import io.github.smiley4.schemakenerator.core.annotations.Format
+import io.github.smiley4.schemakenerator.core.data.AnnotationData
+import io.github.smiley4.schemakenerator.core.data.BaseTypeData
+import io.github.smiley4.schemakenerator.core.data.TypeId
+import io.github.smiley4.schemakenerator.swagger.data.SwaggerSchema
+import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaAnnotationUtils.iterateProperties
+
+/**
+ * Adds format values from [Format]-annotation
+ */
+class SwaggerSchemaCoreAnnotationFormatStep : AbstractSwaggerSchemaStep() {
+
+    override fun process(schema: SwaggerSchema, typeDataMap: Map<TypeId, BaseTypeData>) {
+        if (schema.swagger.format == null) {
+            determineFormat(schema.typeData.annotations)?.also { format ->
+                schema.swagger.format = format
+            }
+        }
+        iterateProperties(schema, typeDataMap) { prop, propData, propTypeData ->
+            determineFormat(propData.annotations + propTypeData.annotations)?.also { format ->
+                prop.format = format
+            }
+        }
+    }
+
+    private fun determineFormat(annotations: Collection<AnnotationData>): String? {
+        return annotations
+            .filter { it.name == Format::class.qualifiedName }
+            .map { it.values["format"] as String }
+            .firstOrNull()
+    }
+
+}

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/KotlinxSerializationParser_SwaggerGenerator_Tests.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/KotlinxSerializationParser_SwaggerGenerator_Tests.kt
@@ -12,6 +12,7 @@ import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotati
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationDeprecatedStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationDescriptionStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationExamplesStep
+import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationFormatStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationTitleStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaGenerationStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaTitleStep
@@ -62,6 +63,7 @@ class KotlinxSerializationParser_SwaggerGenerator_Tests : FunSpec({
                             .let { SwaggerSchemaCoreAnnotationDefaultStep().process(it) }
                             .let { SwaggerSchemaCoreAnnotationExamplesStep().process(it) }
                             .let { SwaggerSchemaCoreAnnotationDeprecatedStep().process(it) }
+                            .let { SwaggerSchemaCoreAnnotationFormatStep().process(it) }
                     } else {
                         list
                     }
@@ -105,6 +107,7 @@ class KotlinxSerializationParser_SwaggerGenerator_Tests : FunSpec({
                             .let { SwaggerSchemaCoreAnnotationDefaultStep().process(it) }
                             .let { SwaggerSchemaCoreAnnotationExamplesStep().process(it) }
                             .let { SwaggerSchemaCoreAnnotationDeprecatedStep().process(it) }
+                            .let { SwaggerSchemaCoreAnnotationFormatStep().process(it) }
                     } else {
                         list
                     }
@@ -154,6 +157,7 @@ class KotlinxSerializationParser_SwaggerGenerator_Tests : FunSpec({
                             .let { SwaggerSchemaCoreAnnotationDefaultStep().process(it) }
                             .let { SwaggerSchemaCoreAnnotationExamplesStep().process(it) }
                             .let { SwaggerSchemaCoreAnnotationDeprecatedStep().process(it) }
+                            .let { SwaggerSchemaCoreAnnotationFormatStep().process(it) }
                     } else {
                         list
                     }
@@ -949,14 +953,16 @@ class KotlinxSerializationParser_SwaggerGenerator_Tests : FunSpec({
                             "value": {
                                 "types": ["string"],
                                 "description": "field description",
-                                "exampleSetFlag": false
+                                "exampleSetFlag": false,
+                                "format": "string"
                             }
                         },
                         "description": "some description",
                         "deprecated": true,
                         "exampleSetFlag": true,
                         "example": "example 1",
-                        "default": "default value"
+                        "default": "default value",
+                        "format": "object"
                     }
                 """.trimIndent(),
                 expectedResultReferencing = """
@@ -971,14 +977,16 @@ class KotlinxSerializationParser_SwaggerGenerator_Tests : FunSpec({
                                 "value": {
                                     "types": ["string"],
                                     "description": "field description",
-                                    "exampleSetFlag": false
+                                    "exampleSetFlag": false,
+                                    "format": "string"
                                 }
                             },
                             "description": "some description",
                             "deprecated": true,
                             "exampleSetFlag": true,
                             "example": "example 1",
-                            "default": "default value"
+                            "default": "default value",
+                            "format": "object"
                         },
                         "definitions": {}
                     }
@@ -1000,14 +1008,16 @@ class KotlinxSerializationParser_SwaggerGenerator_Tests : FunSpec({
                                     "value": {
                                         "types": ["string"],
                                         "description": "field description",
-                                        "exampleSetFlag": false
+                                        "exampleSetFlag": false,
+                                        "format": "string"
                                     }
                                 },
                                 "description": "some description",
                                 "deprecated": true,
                                 "exampleSetFlag": true,
                                 "example": "example 1",
-                                "default": "default value"
+                                "default": "default value",
+                                "format": "object"
                             }
                         }
                     }

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/ReflectionParser_JsonGenerator_Tests.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/ReflectionParser_JsonGenerator_Tests.kt
@@ -11,6 +11,7 @@ import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotati
 import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotationDeprecatedStep
 import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotationDescriptionStep
 import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotationExamplesStep
+import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotationFormatStep
 import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaCoreAnnotationTitleStep
 import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaGenerationStep
 import io.github.smiley4.schemakenerator.jsonschema.steps.JsonSchemaTitleStep
@@ -61,6 +62,7 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                             .let { JsonSchemaCoreAnnotationDefaultStep().process(it) }
                             .let { JsonSchemaCoreAnnotationExamplesStep().process(it) }
                             .let { JsonSchemaCoreAnnotationDeprecatedStep().process(it) }
+                            .let { JsonSchemaCoreAnnotationFormatStep().process(it) }
                     } else {
                         list
                     }
@@ -105,6 +107,7 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                             .let { JsonSchemaCoreAnnotationDefaultStep().process(it) }
                             .let { JsonSchemaCoreAnnotationExamplesStep().process(it) }
                             .let { JsonSchemaCoreAnnotationDeprecatedStep().process(it) }
+                            .let { JsonSchemaCoreAnnotationFormatStep().process(it) }
                     } else {
                         list
                     }
@@ -158,6 +161,7 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                             .let { JsonSchemaCoreAnnotationDefaultStep().process(it) }
                             .let { JsonSchemaCoreAnnotationExamplesStep().process(it) }
                             .let { JsonSchemaCoreAnnotationDeprecatedStep().process(it) }
+                            .let { JsonSchemaCoreAnnotationFormatStep().process(it) }
                     } else {
                         list
                     }
@@ -862,7 +866,8 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                                 "default": "A default String value",
                                 "examples": [
                                     "An example of a String value"
-                                ]
+                                ],
+                                "format": "text"
                             },
                             "intValue": {
                                 "type": "integer",
@@ -872,7 +877,8 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                                 "description": "Int field description",
                                 "examples": [
                                     "2222"
-                                ]
+                                ],
+                                "format": "int32"
                             }
                         },
                         "title": "Annotated Class",
@@ -881,7 +887,8 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                         "examples": [
                             "example 1"
                         ],
-                        "deprecated": true
+                        "deprecated": true,
+                        "format": "pair"
                     }
                 """.trimIndent(),
                 expectedResultReferencing = """
@@ -895,7 +902,8 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                                 "default": "A default String value",
                                 "examples": [
                                     "An example of a String value"
-                                ]
+                                ],
+                                "format": "text"
                             },
                             "intValue": {
                                 "type": "integer",
@@ -905,7 +913,8 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                                 "description": "Int field description",
                                 "examples": [
                                     "2222"
-                                ]
+                                ],
+                                "format": "int32"
                             }
                         },
                         "title": "Annotated Class",
@@ -914,7 +923,8 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                         "examples": [
                             "example 1"
                         ],
-                        "deprecated": true
+                        "deprecated": true,
+                        "format": "pair"
                     }
                 """.trimIndent(),
                 expectedResultReferencingRoot = """
@@ -931,7 +941,8 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                                         "default": "A default String value",
                                         "examples": [
                                             "An example of a String value"
-                                        ]
+                                        ],
+                                        "format": "text"
                                     },
                                     "intValue": {
                                         "type": "integer",
@@ -941,7 +952,8 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                                         "description": "Int field description",
                                         "examples": [
                                             "2222"
-                                        ]
+                                        ],
+                                        "format": "int32"
                                     }
                                 },
                                 "title": "Annotated Class",
@@ -950,7 +962,8 @@ class ReflectionParser_JsonGenerator_Tests : FunSpec({
                                 "examples": [
                                     "example 1"
                                 ],
-                                "deprecated": true
+                                "deprecated": true,
+                                "format": "pair"
                             }
                         }
                     }

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/ReflectionParser_SwaggerGenerator_Tests.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/ReflectionParser_SwaggerGenerator_Tests.kt
@@ -14,6 +14,7 @@ import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotati
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationDeprecatedStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationDescriptionStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationExamplesStep
+import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationFormatStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaCoreAnnotationTitleStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaGenerationStep
 import io.github.smiley4.schemakenerator.swagger.steps.SwaggerSchemaTitleStep
@@ -65,6 +66,7 @@ class ReflectionParser_SwaggerGenerator_Tests : FunSpec({
                             .let { SwaggerSchemaCoreAnnotationDefaultStep().process(it) }
                             .let { SwaggerSchemaCoreAnnotationExamplesStep().process(it) }
                             .let { SwaggerSchemaCoreAnnotationDeprecatedStep().process(it) }
+                            .let { SwaggerSchemaCoreAnnotationFormatStep().process(it) }
                             .let { SwaggerSchemaAnnotationStep().process(it) }
                             .let { SwaggerArraySchemaAnnotationStep().process(it) }
                     } else {
@@ -116,6 +118,7 @@ class ReflectionParser_SwaggerGenerator_Tests : FunSpec({
                             .let { SwaggerSchemaCoreAnnotationDefaultStep().process(it) }
                             .let { SwaggerSchemaCoreAnnotationExamplesStep().process(it) }
                             .let { SwaggerSchemaCoreAnnotationDeprecatedStep().process(it) }
+                            .let { SwaggerSchemaCoreAnnotationFormatStep().process(it) }
                             .let { SwaggerSchemaAnnotationStep().process(it) }
                             .let { SwaggerArraySchemaAnnotationStep().process(it) }
                     } else {
@@ -167,6 +170,7 @@ class ReflectionParser_SwaggerGenerator_Tests : FunSpec({
                             .let { SwaggerSchemaCoreAnnotationDefaultStep().process(it) }
                             .let { SwaggerSchemaCoreAnnotationExamplesStep().process(it) }
                             .let { SwaggerSchemaCoreAnnotationDeprecatedStep().process(it) }
+                            .let { SwaggerSchemaCoreAnnotationFormatStep().process(it) }
                             .let { SwaggerSchemaAnnotationStep().process(it) }
                             .let { SwaggerArraySchemaAnnotationStep().process(it) }
                     } else {
@@ -1127,7 +1131,8 @@ class ReflectionParser_SwaggerGenerator_Tests : FunSpec({
                                     "description": "String field description",
                                     "default": "A default String value",
                                     "exampleSetFlag": true,
-                                    "example": "An example of a String value"
+                                    "example": "An example of a String value",
+                                    "format": "text"
                                 },
                                 "intValue": {
                                     "types": ["integer"],
@@ -1142,7 +1147,8 @@ class ReflectionParser_SwaggerGenerator_Tests : FunSpec({
                             "deprecated": true,
                             "exampleSetFlag": true,
                             "example": "example 1",
-                            "default": "default value"
+                            "default": "default value",
+                            "format": "pair"
                         },
                         "definitions": {}
                     }
@@ -1162,7 +1168,8 @@ class ReflectionParser_SwaggerGenerator_Tests : FunSpec({
                                     "description": "String field description",
                                     "default": "A default String value",
                                     "exampleSetFlag": true,
-                                    "example": "An example of a String value"
+                                    "example": "An example of a String value",
+                                    "format": "text"
                                 },
                                 "intValue": {
                                     "types": ["integer"],
@@ -1177,7 +1184,8 @@ class ReflectionParser_SwaggerGenerator_Tests : FunSpec({
                             "deprecated": true,
                             "exampleSetFlag": true,
                             "example": "example 1",
-                            "default": "default value"
+                            "default": "default value",
+                            "format": "pair"
                         },
                         "definitions": {}
                     }
@@ -1202,7 +1210,8 @@ class ReflectionParser_SwaggerGenerator_Tests : FunSpec({
                                         "description": "String field description",
                                         "default": "A default String value",
                                         "exampleSetFlag": true,
-                                        "example": "An example of a String value"
+                                        "example": "An example of a String value",
+                                        "format": "text"
                                     },
                                     "intValue": {
                                         "types": ["integer"],
@@ -1217,7 +1226,8 @@ class ReflectionParser_SwaggerGenerator_Tests : FunSpec({
                                 "deprecated": true,
                                 "exampleSetFlag": true,
                                 "example": "example 1",
-                                "default": "default value"
+                                "default": "default value",
+                                "format": "pair"
                             }
                         }
                     }

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/models/kotlinx/CoreAnnotatedClass.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/models/kotlinx/CoreAnnotatedClass.kt
@@ -4,6 +4,7 @@ import io.github.smiley4.schemakenerator.core.annotations.Default
 import io.github.smiley4.schemakenerator.core.annotations.Deprecated
 import io.github.smiley4.schemakenerator.core.annotations.Description
 import io.github.smiley4.schemakenerator.core.annotations.Example
+import io.github.smiley4.schemakenerator.core.annotations.Format
 import io.github.smiley4.schemakenerator.core.annotations.Title
 import kotlinx.serialization.Serializable
 
@@ -12,8 +13,10 @@ import kotlinx.serialization.Serializable
 @Description("some description")
 @Default("default value")
 @Example("example 1")
+@Format("object")
 @Deprecated
 class CoreAnnotatedClass(
     @Description("field description")
+    @Format("string")
     val value: String
 )

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/models/reflection/CoreAnnotatedClass.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/models/reflection/CoreAnnotatedClass.kt
@@ -4,22 +4,25 @@ import io.github.smiley4.schemakenerator.core.annotations.Default
 import io.github.smiley4.schemakenerator.core.annotations.Deprecated
 import io.github.smiley4.schemakenerator.core.annotations.Description
 import io.github.smiley4.schemakenerator.core.annotations.Example
+import io.github.smiley4.schemakenerator.core.annotations.Format
 import io.github.smiley4.schemakenerator.core.annotations.Title
-
 
 @Title("Annotated Class")
 @Description("some description")
 @Default("default value")
 @Example("example 1")
+@Format("pair")
 @Deprecated
 class CoreAnnotatedClass(
     @Description("String field description")
     @Default("A default String value")
     @Example("An example of a String value")
+    @Format("text")
     val stringValue: String,
 
     @Description("Int field description")
     @Default("1111")
     @Example("2222")
+    @Format("int32")
     val intValue: Int,
 )


### PR DESCRIPTION
See: https://swagger.io/docs/specification/v3_0/data-models/data-types/#string-formats
See: https://json-schema.org/draft/2020-12/json-schema-validation#name-vocabularies-for-semantic-c