### PR TITLE
fix: support nullable nested sub classes for kotlinx serialization

### DIFF
--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzerImpl.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzerImpl.kt
@@ -118,7 +118,7 @@ internal class SerializationTypeAnalyzerImpl(
         // reserve this descriptor / mark this descriptor as processed with a pending result
         // reserve type-id so that other types can already reference this type (e.g. members resulting in a reference loop)
         val reservedTypeId = TypeId.create()
-        processedDescriptors[descriptor] = TypeData.createPlaceholder(reservedTypeId)
+        processedDescriptors[descriptor.nonNullOriginal] = TypeData.createPlaceholder(reservedTypeId)
 
         // check type redirects
         if (typeRedirects.containsKey(descriptor.redirectKey(nullable))) {

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/KotlinxSerializationParser_SwaggerGenerator_Tests.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/KotlinxSerializationParser_SwaggerGenerator_Tests.kt
@@ -10,18 +10,7 @@ import io.github.smiley4.schemakenerator.swagger.generateSwaggerSchema
 import io.github.smiley4.schemakenerator.swagger.TitleBuilder
 import io.github.smiley4.schemakenerator.swagger.handleCoreAnnotations
 import io.github.smiley4.schemakenerator.swagger.withTitle
-import io.github.smiley4.schemakenerator.test.models.kotlinx.ClassDirectSelfReferencing
-import io.github.smiley4.schemakenerator.test.models.kotlinx.ClassWithCollections
-import io.github.smiley4.schemakenerator.test.models.kotlinx.ClassWithDeepGeneric
-import io.github.smiley4.schemakenerator.test.models.kotlinx.ClassWithGenericField
-import io.github.smiley4.schemakenerator.test.models.kotlinx.ClassWithNestedClass
-import io.github.smiley4.schemakenerator.test.models.kotlinx.ClassWithOptionalParameters
-import io.github.smiley4.schemakenerator.test.models.kotlinx.ClassWithSimpleFields
-import io.github.smiley4.schemakenerator.test.models.kotlinx.ClassWithValueClass
-import io.github.smiley4.schemakenerator.test.models.kotlinx.CoreAnnotatedClass
-import io.github.smiley4.schemakenerator.test.models.kotlinx.SealedClass
-import io.github.smiley4.schemakenerator.test.models.kotlinx.SubClassA
-import io.github.smiley4.schemakenerator.test.models.kotlinx.TestEnum
+import io.github.smiley4.schemakenerator.test.models.kotlinx.*
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.WithDataTestName
 import io.kotest.datatest.withData
@@ -1600,8 +1589,237 @@ class KotlinxSerializationParser_SwaggerGenerator_Tests : FunSpec({
                     """.trimIndent()
                 )
             ),
+            TestData(
+                type = typeOf<NullableClasses.NullableFirst>(),
+                testName = "class with nullable first",
+                generatorConfig = { nullables = RequiredHandling.REQUIRED },
+                expectedResultInlining = """
+                    {
+                      "type": "object",
+                      "properties": {
+                        "t1": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "count": {
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          },
+                          "required": [
+                            "count"
+                          ]
+                        },
+                        "t2": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          },
+                          "required": [
+                            "count"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "t1",
+                        "t2"
+                      ]
+                    }
+                """.trimIndent(),
+                expectedResultReferencing = mapOf(
+                    "." to """
+                        {
+                          "type": "object",
+                          "properties": {
+                            "t1": {
+                              "oneOf": [
+                                {
+                                  "type": "null"
+                                },
+                                {
+                                  "${'$'}ref": "#/components/schemas/io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.Test"
+                                }
+                              ]
+                            },
+                            "t2": {
+                              "${'$'}ref": "#/components/schemas/io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.Test"
+                            }
+                          },
+                          "required": [
+                            "t1",
+                            "t2"
+                          ]
+                        }
+                    """.trimIndent(),
+                    "io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.Test" to "..."
+                ),
+                expectedResultReferencingRoot = mapOf(
+                    "." to """
+                      {
+                        "${'$'}ref": "#/components/schemas/io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.NullableFirst"
+                      }
+                    """.trimIndent(),
+                    "io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.NullableFirst" to """
+                        {
+                          "type": "object",
+                          "properties": {
+                            "t1": {
+                              "oneOf": [
+                                {
+                                  "type": "null"
+                                },
+                                {
+                                  "${'$'}ref": "#/components/schemas/io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.Test"
+                                }
+                              ]
+                            },
+                            "t2": {
+                              "${'$'}ref": "#/components/schemas/io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.Test"
+                            }
+                          },
+                          "required": [
+                            "t1",
+                            "t2"
+                          ]
+                        }
+                    """.trimIndent(),
+                    "io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.Test" to """
+                        {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          },
+                          "required": [
+                            "count"
+                          ]
+                        }
+                    """.trimIndent()
+                )
+            ),
+            TestData(
+                type = typeOf<NullableClasses.NullableSecond>(),
+                testName = "class with nullable second",
+                generatorConfig = { nullables = RequiredHandling.REQUIRED },
+                expectedResultInlining = """
+                    {
+                      "type": "object",
+                      "properties": {
+                        "t1": {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          },
+                          "required": [
+                            "count"
+                          ]
+                        },
+                        "t2": {
+                          "type": [
+                            "null",
+                            "object"
+                          ],
+                          "properties": {
+                            "count": {
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          },
+                          "required": [
+                            "count"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "t1",
+                        "t2"
+                      ]
+                    }
+                """.trimIndent(),
+                expectedResultReferencing = mapOf(
+                    "." to """
+                        {
+                          "type": "object",
+                          "properties": {
+                            "t1": {
+                              "${'$'}ref": "#/components/schemas/io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.Test"
+                            },
+                            "t2": {
+                              "oneOf": [
+                                {
+                                  "type": "null"
+                                },
+                                {
+                                  "${'$'}ref": "#/components/schemas/io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.Test"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "t1",
+                            "t2"
+                          ]
+                        }
+                    """.trimIndent(),
+                    "io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.Test" to "..."
+                ),
+                expectedResultReferencingRoot = mapOf(
+                    "." to """
+                      {
+                        "${'$'}ref": "#/components/schemas/io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.NullableSecond"
+                      }
+                    """.trimIndent(),
+                    "io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.NullableSecond" to """
+                        {
+                          "type": "object",
+                          "properties": {
+                            "t1": {
+                              "${'$'}ref": "#/components/schemas/io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.Test"
+                            },
+                            "t2": {
+                              "oneOf": [
+                                {
+                                  "type": "null"
+                                },
+                                {
+                                  "${'$'}ref": "#/components/schemas/io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.Test"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "t1",
+                            "t2"
+                          ]
+                        }
+                    """.trimIndent(),
+                    "io.github.smiley4.schemakenerator.test.models.kotlinx.NullableClasses.Test" to """
+                        {
+                          "type": "object",
+                          "properties": {
+                            "count": {
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          },
+                          "required": [
+                            "count"
+                          ]
+                        }
+                    """.trimIndent()
+                )
+            ),
         )
-
     }
 
 }

--- a/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/models/kotlinx/ClassWithNullableClasses.kt
+++ b/schema-kenerator-test/src/test/kotlin/io/github/smiley4/schemakenerator/test/models/kotlinx/ClassWithNullableClasses.kt
@@ -1,0 +1,14 @@
+package io.github.smiley4.schemakenerator.test.models.kotlinx
+
+import kotlinx.serialization.Serializable
+
+interface NullableClasses {
+    @Serializable
+    class NullableFirst(val t1: Test?, val t2: Test)
+
+    @Serializable
+    class NullableSecond(val t1: Test, val t2: Test?)
+
+    @Serializable
+    class Test(val count: Int)
+}


### PR DESCRIPTION
Fixes issue where a given type has properties (or nested) that reference the same class in multiple places, but some properties are defined with the nullable class and others with non nullable, can cause a dangling reference in the analyzed types.