### PR TITLE
Allow multiple classes with the same @SerialName value and allow inlining of discriminated types

### DIFF
--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/DefaultSerializationTypeAnalyzerModule.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/DefaultSerializationTypeAnalyzerModule.kt
@@ -83,10 +83,10 @@ class DefaultSerializationTypeAnalyzerModule(
     private fun analyzePrimitive(context: SerializationTypeAnalyzerModule.Context, identifyingName: TypeName): TypeData {
 
         // create basic information for this type
-        val descriptiveName = context.descriptor.toTypeName()
+        val descriptiveName = context.toTypeName()
 
         // check type has already been parsed
-        val existing = context.knownTypeData.find { known -> known.matches(identifyingName, descriptiveName, emptyList()) }
+        val existing = context.findKnown(identifyingName, descriptiveName)
         if (existing != null) {
             return existing
         }
@@ -119,8 +119,7 @@ class DefaultSerializationTypeAnalyzerModule(
     private fun analyzeList(context: SerializationTypeAnalyzerModule.Context): TypeData {
 
         // create basic information for this type
-        val descriptiveName = context.descriptor.toTypeName()
-        val identifyingName = context.descriptor.toTypeName()
+        val name = context.toTypeName()
 
         // collect information about item type
         val itemDescriptor = context.descriptor.getElementDescriptor(0)
@@ -133,7 +132,7 @@ class DefaultSerializationTypeAnalyzerModule(
         )
 
         // check type has already been parsed
-        val existing = context.knownTypeData.find { known -> known.matches(identifyingName, descriptiveName, listOf(itemParameter)) }
+        val existing = context.findKnown(typeParameters = listOf(itemParameter))
         if (existing != null) {
             return existing
         }
@@ -148,8 +147,8 @@ class DefaultSerializationTypeAnalyzerModule(
         // build type
         return TypeData(
             id = context.id,
-            identifyingName = identifyingName,
-            descriptiveName = descriptiveName,
+            identifyingName = name,
+            descriptiveName = name,
             typeParameters = mutableListOf(itemParameter),
             annotations = annotations,
             subtypes = mutableListOf(),
@@ -181,8 +180,7 @@ class DefaultSerializationTypeAnalyzerModule(
     private fun analyzeMap(context: SerializationTypeAnalyzerModule.Context): TypeData {
 
         // create basic information for this type
-        val descriptiveName = context.descriptor.toTypeName()
-        val identifyingName = context.descriptor.toTypeName()
+        val name = context.toTypeName()
 
         // collect information about key type
         val keyDescriptor = context.descriptor.getElementDescriptor(0)
@@ -205,8 +203,7 @@ class DefaultSerializationTypeAnalyzerModule(
         )
 
         // check type has already been parsed
-        val existing =
-            context.knownTypeData.find { known -> known.matches(identifyingName, descriptiveName, listOf(keyParameter, valueParameter)) }
+        val existing = context.findKnown(typeParameters = listOf(keyParameter, valueParameter))
         if (existing != null) {
             return existing
         }
@@ -217,8 +214,8 @@ class DefaultSerializationTypeAnalyzerModule(
         // build type
         return TypeData(
             id = context.id,
-            identifyingName = identifyingName,
-            descriptiveName = descriptiveName,
+            identifyingName = name,
+            descriptiveName = name,
             typeParameters = mutableListOf(keyParameter, valueParameter),
             annotations = annotations,
             subtypes = mutableListOf(),
@@ -258,8 +255,7 @@ class DefaultSerializationTypeAnalyzerModule(
     private fun analyzeClass(context: SerializationTypeAnalyzerModule.Context): TypeData {
 
         // create basic information for this type
-        val descriptiveName = context.descriptor.toTypeName()
-        val identifyingName = context.descriptor.toTypeName()
+        val name = context.toTypeName()
 
         // extract type parameters using reflection (if enabled)
         val typeParameters = if (findTypeParametersUsingReflection) {
@@ -276,7 +272,7 @@ class DefaultSerializationTypeAnalyzerModule(
         }
 
         // Check type has already been parsed.
-        val existing = context.knownTypeData.find { known -> known.matches(identifyingName, descriptiveName, typeParameters) }
+        val existing = context.findKnown(typeParameters = typeParameters)
         if (existing != null) {
             return existing
         }
@@ -310,8 +306,8 @@ class DefaultSerializationTypeAnalyzerModule(
         // build type
         return TypeData(
             id = context.id,
-            identifyingName = identifyingName,
-            descriptiveName = descriptiveName,
+            identifyingName = name,
+            descriptiveName = name,
             typeParameters = typeParameters.toMutableList(),
             annotations = annotations,
             subtypes = mutableListOf(),
@@ -332,8 +328,7 @@ class DefaultSerializationTypeAnalyzerModule(
     private fun analyzeSealed(context: SerializationTypeAnalyzerModule.Context): TypeData {
 
         // create basic information for this type
-        val descriptiveName = context.descriptor.toTypeName()
-        val identifyingName = context.descriptor.toTypeName()
+        val name = context.toTypeName()
 
         // extract type parameters using reflection (if enabled)
         val typeParameters = if (findTypeParametersUsingReflection) {
@@ -350,7 +345,7 @@ class DefaultSerializationTypeAnalyzerModule(
         }
 
         // Check type has already been parsed.
-        val existing = context.knownTypeData.find { known -> known.matches(identifyingName, descriptiveName, typeParameters) }
+        val existing = context.findKnown(typeParameters = typeParameters)
         if (existing != null) {
             return existing
         }
@@ -366,8 +361,8 @@ class DefaultSerializationTypeAnalyzerModule(
         // build type
         return TypeData(
             id = context.id,
-            identifyingName = identifyingName,
-            descriptiveName = descriptiveName,
+            identifyingName = name,
+            descriptiveName = name,
             typeParameters = mutableListOf(),
             annotations = annotations,
             subtypes = subtypes.toMutableList(),
@@ -388,11 +383,10 @@ class DefaultSerializationTypeAnalyzerModule(
     private fun analyzeObject(context: SerializationTypeAnalyzerModule.Context): TypeData {
 
         // create basic information for this type
-        val descriptiveName = context.descriptor.toTypeName()
-        val identifyingName = context.descriptor.toTypeName()
+        val name = context.toTypeName()
 
         // check type has already been parsed
-        val existing = context.knownTypeData.find { known -> known.matches(identifyingName, descriptiveName, listOf()) }
+        val existing = context.findKnown()
         if (existing != null) {
             return existing
         }
@@ -403,8 +397,8 @@ class DefaultSerializationTypeAnalyzerModule(
         // build type
         return TypeData(
             id = context.id,
-            identifyingName = identifyingName,
-            descriptiveName = descriptiveName,
+            identifyingName = name,
+            descriptiveName = name,
             typeParameters = mutableListOf(),
             annotations = annotations,
             subtypes = mutableListOf(),
@@ -425,11 +419,10 @@ class DefaultSerializationTypeAnalyzerModule(
     private fun analyzeEnum(context: SerializationTypeAnalyzerModule.Context): TypeData {
 
         // create basic information for this type
-        val descriptiveName = context.descriptor.toTypeName()
-        val identifyingName = context.descriptor.toTypeName()
+        val name = context.toTypeName()
 
         // check type has already been parsed
-        val existing = context.knownTypeData.find { known -> known.matches(identifyingName, descriptiveName, listOf()) }
+        val existing = context.findKnown()
         if (existing != null) {
             return existing
         }
@@ -443,8 +436,8 @@ class DefaultSerializationTypeAnalyzerModule(
         // build type
         return TypeData(
             id = TypeId.create(),
-            identifyingName = identifyingName,
-            descriptiveName = descriptiveName,
+            identifyingName = name,
+            descriptiveName = name,
             typeParameters = mutableListOf(),
             annotations = annotations,
             subtypes = mutableListOf(),
@@ -480,15 +473,6 @@ class DefaultSerializationTypeAnalyzerModule(
     private fun KClass<*>.toTypeName() = TypeName(
         full = this.qualifiedName ?: this.java.name,
         short = this.simpleName ?: this.java.name
-    )
-
-
-    /**
-     * @return a [TypeName] for this class
-     */
-    private fun SerialDescriptor.toTypeName() = TypeName(
-        full = this.fullName(),
-        short = this.serialName.split(".").last().replace("?", "")
     )
 
 }

--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzerModule.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzerModule.kt
@@ -1,7 +1,10 @@
 package io.github.smiley4.schemakenerator.serialization.analyzer
 
 import io.github.smiley4.schemakenerator.core.data.TypeData
+import io.github.smiley4.schemakenerator.core.data.TypeDataUtils.matches
 import io.github.smiley4.schemakenerator.core.data.TypeId
+import io.github.smiley4.schemakenerator.core.data.TypeName
+import io.github.smiley4.schemakenerator.core.data.TypeParameterData
 import io.github.smiley4.schemakenerator.core.data.WrappedTypeData
 import kotlinx.serialization.descriptors.SerialDescriptor
 
@@ -23,6 +26,30 @@ interface SerializationTypeAnalyzerModule {
             )
         }
 
+        fun findKnown(
+            identifyingName: TypeName = descriptor.toTypeName(),
+            descriptiveName: TypeName = descriptor.toTypeName(),
+            typeParameters: List<TypeParameterData> = emptyList()) : TypeData?
+        {
+            // Only find a matching type by name AND serial descriptor.  The addition of comparing serial descriptors is
+            // REQUIRED when the types have matching @SerialName values.
+            return knownTypeData.find { known ->
+                known.matches(identifyingName, descriptiveName, typeParameters) &&
+                        cache.getDescriptor(known)?.equals(descriptor) ?: false
+            }
+        }
+
+        /**
+         * @return a [TypeName] for this class
+         */
+        private fun SerialDescriptor.toTypeName() = TypeName(
+            full = this.fullName(),
+            short = this.serialName.split(".").last().replace("?", "")
+        )
+
+        fun toTypeName(): TypeName {
+            return descriptor.toTypeName()
+        }
     }
 
 

--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzerModule.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzerModule.kt
@@ -35,7 +35,7 @@ interface SerializationTypeAnalyzerModule {
             // REQUIRED when the types have matching @SerialName values.
             return knownTypeData.find { known ->
                 known.matches(identifyingName, descriptiveName, typeParameters) &&
-                        cache.getDescriptor(known)?.equals(descriptor) ?: false
+                        cache.getDescriptor(known)?.equals(descriptor) ?: true
             }
         }
 

--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/TypeDataCache.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/TypeDataCache.kt
@@ -6,7 +6,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.nonNullOriginal
 
 @OptIn(ExperimentalSerializationApi::class)
-class TypeDataCache(private val entries: MutableMap<SerialDescriptor, TypeData> = mutableMapOf()) {
+class TypeDataCache(
+    private val entries: MutableMap<SerialDescriptor, TypeData> = mutableMapOf(),
+    private val reversedEntries: MutableMap<TypeData, SerialDescriptor> = mutableMapOf()
+) {
 
     /**
      * Cache the given [TypeData] for the given [SerialDescriptor]. The nullability of the descriptor is irrelevant
@@ -15,6 +18,7 @@ class TypeDataCache(private val entries: MutableMap<SerialDescriptor, TypeData> 
      * */
     operator fun set(descriptor: SerialDescriptor, typeData: TypeData) {
         entries[descriptor.nonNullOriginal] = typeData
+        reversedEntries[typeData] = descriptor.nonNullOriginal
     }
 
 
@@ -27,4 +31,11 @@ class TypeDataCache(private val entries: MutableMap<SerialDescriptor, TypeData> 
         return entries[descriptor.nonNullOriginal]
     }
 
+    /**
+     * Retrieve the [SerialDescriptor] for the given [TypeData]
+     *
+     * @param typeData the [TypeData] for the descriptor
+     * @return the [SerialDescriptor] for the given type data or null
+     */
+    fun getDescriptor(typeData: TypeData): SerialDescriptor? = reversedEntries[typeData]
 }

--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/SwaggerSchemaCompileReferenceRootStep.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/SwaggerSchemaCompileReferenceRootStep.kt
@@ -8,6 +8,7 @@ import io.github.smiley4.schemakenerator.swagger.data.IntermediateSwaggerSchemaD
 
 internal class SwaggerSchemaCompileReferenceRootStep(
     private val explicitNullTypes: Boolean,
+    private val inlineDiscriminatedTypes: Boolean,
     private val pathBuilder: (type: TypeData, types: Map<TypeId, TypeData>) -> String
 ) {
 
@@ -17,7 +18,7 @@ internal class SwaggerSchemaCompileReferenceRootStep(
      * Put referenced schemas into definitions and reference them
      */
     fun compile(input: IntermediateSwaggerSchemaData): CompiledSwaggerSchemaData {
-        val result = SwaggerSchemaCompileReferenceStep(explicitNullTypes, pathBuilder).compile(input)
+        val result = SwaggerSchemaCompileReferenceStep(explicitNullTypes, inlineDiscriminatedTypes, pathBuilder).compile(input)
         if (shouldReference(result.swagger, result.typeData)) {
             val refPath = pathBuilder(result.typeData, input.typeDataById)
             return CompiledSwaggerSchemaData(

--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/SwaggerSchemaCompileReferenceStep.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/SwaggerSchemaCompileReferenceStep.kt
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.models.media.Schema
 
 internal class SwaggerSchemaCompileReferenceStep(
     private val explicitNullTypes: Boolean,
+    private val inlineDiscriminatedTypes: Boolean,
     private val pathBuilder: (type: TypeData, types: Map<TypeId, TypeData>) -> String
 ) {
 
@@ -86,8 +87,14 @@ internal class SwaggerSchemaCompileReferenceStep(
             return refObj
         }
 
+        val shouldInline = inlineDiscriminatedTypes &&
+                (referencedSchema.swagger.discriminator != null
+                        || context.knownSchemas.firstOrNull {
+                            it.swagger.anyOf?.contains(refObj) == true || it.swagger.oneOf?.contains(refObj) == true
+                        } != null)
+
         // create swagger property with correct reference path (and add actual schema to context)
-        val property = if (shouldReference(referencedSchema.swagger, referencedSchema.typeData)) {
+        val property = if (shouldReference(referencedSchema.swagger, referencedSchema.typeData) && !shouldInline) {
             createRefProperty(refObj, referencedSchema, context)
         } else {
             createInlineProperty(refObj, referencedSchema)

--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/SwaggerSteps.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/SwaggerSteps.kt
@@ -133,14 +133,17 @@ object SwaggerSteps {
     /**
      * Resolves references in generated swagger schemas by collecting them in the components-section and referencing them.
      * @param explicitNullTypes whether to explicitly add "null" as a type to nullable fields.
+     * @param inlineDiscriminatedTypes if this is true and a type is discriminated, it will be compiled inline.
      * @param pathType the type of the schema reference path
      */
     fun IntermediateSwaggerSchemaData.compileReferencing(
         explicitNullTypes: Boolean = true,
+        inlineDiscriminatedTypes: Boolean = false,
         pathType: RefType = RefType.OPENAPI_FULL
     ): CompiledSwaggerSchemaData {
         return compileReferencing(
             explicitNullTypes,
+            inlineDiscriminatedTypes,
             when (pathType) {
                 RefType.FULL -> TitleBuilder.BUILDER_FULL
                 RefType.SIMPLE -> TitleBuilder.BUILDER_SIMPLE
@@ -154,27 +157,31 @@ object SwaggerSteps {
     /**
      * Resolves references in generated swagger schemas by collecting them in the components-section and referencing them.
      * @param explicitNullTypes whether to explicitly add "null" as a type to nullable fields.
+     * @param inlineDiscriminatedTypes if this is true and a type is discriminated, it will be compiled inline.
      * @param builder builds the path to reference the type, i.e. which "name" to use
      */
     fun IntermediateSwaggerSchemaData.compileReferencing(
         explicitNullTypes: Boolean = true,
+        inlineDiscriminatedTypes: Boolean = false,
         builder: (type: TypeData, types: Map<TypeId, TypeData>) -> String
     ): CompiledSwaggerSchemaData {
-        return SwaggerSchemaCompileReferenceStep(explicitNullTypes, builder).compile(this)
+        return SwaggerSchemaCompileReferenceStep(explicitNullTypes, inlineDiscriminatedTypes, builder).compile(this)
     }
-
 
     /**
      * Resolves references in generated swagger schemas by collecting them in the components-section and referencing them.
      * @param explicitNullTypes whether to explicitly add "null" as a type to nullable fields.
+     * @param inlineDiscriminatedTypes if this is true and a type is discriminated, it will be compiled inline.
      * @param pathType the type of the schema reference path
      */
     fun IntermediateSwaggerSchemaData.compileReferencingRoot(
         explicitNullTypes: Boolean = true,
+        inlineDiscriminatedTypes: Boolean = false,
         pathType: RefType = RefType.OPENAPI_FULL
     ): CompiledSwaggerSchemaData {
         return compileReferencingRoot(
             explicitNullTypes,
+            inlineDiscriminatedTypes,
             when (pathType) {
                 RefType.FULL -> TitleBuilder.BUILDER_FULL
                 RefType.SIMPLE -> TitleBuilder.BUILDER_SIMPLE
@@ -187,14 +194,16 @@ object SwaggerSteps {
 
     /**
      * Resolves references in generated swagger schemas by collecting them in the components-section and referencing them.
-     * @param explicitNullTypes whether to explicitly add "null" as a type to nullable fields.
+     * @param explicitNullTypes whether to explicitly add "null" as a type to nullable fields
+     * @param inlineDiscriminatedTypes if this is true and a type is discriminated, it will be compiled inline.
      * @param builder builds the path to reference the type, i.e. which "name" to use
      */
     fun IntermediateSwaggerSchemaData.compileReferencingRoot(
         explicitNullTypes: Boolean = true,
+        inlineDiscriminatedTypes: Boolean = false,
         builder: (type: TypeData, types: Map<TypeId, TypeData>) -> String
     ): CompiledSwaggerSchemaData {
-        return SwaggerSchemaCompileReferenceRootStep(explicitNullTypes, builder).compile(this)
+        return SwaggerSchemaCompileReferenceRootStep(explicitNullTypes, inlineDiscriminatedTypes, builder).compile(this)
     }
 
 


### PR DESCRIPTION
Allows: 

```kotlin
@Serializable
@JsonClassDiscriminator("type")
sealed class ClassA {
    @Serializable
    @SerialName("A")
    data class SubclassA(val unique1: String) : ClassA()

    @Serializable
    @SerialName("B")
    data class SubclassB(val unique2: String) : ClassA()
}

@Serializable
@JsonClassDiscriminator("type")
sealed class ClassB {
    @Serializable
    @SerialName("A")
    data class SubclassA(val unique3: String) : ClassB()

    @Serializable
    @SerialName("B")
    data class SubclassB(val unique4: String) : ClassB()
}

@Serializable
data class ClassWithConflictingSerialNames(
    val a: ClassA,
    val b: ClassB
)
```