### PR TITLE
fix: npe in schema annotation handler

### DIFF
--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/SwaggerSchemaAnnotationStep.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/SwaggerSchemaAnnotationStep.kt
@@ -51,7 +51,7 @@ internal class SwaggerSchemaAnnotationStep {
                 when(it) {
                     Schema.RequiredMode.AUTO -> Unit
                     Schema.RequiredMode.REQUIRED -> {
-                        if(!schema.swagger.required.contains(prop.name)) {
+                        if(schema.swagger.required?.contains(prop.name) != true) {
                             schema.swagger.required.add(prop.name)
                         }
                     }

--- a/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/SwaggerSchemaAnnotationUtils.kt
+++ b/schema-kenerator-swagger/src/main/kotlin/io/github/smiley4/schemakenerator/swagger/SwaggerSchemaAnnotationUtils.kt
@@ -28,7 +28,7 @@ object SwaggerSchemaAnnotationUtils {
             }
             propertiesToRename.forEach {(prevName, newName) ->
                 schema.swagger.properties[newName] = schema.swagger.properties.remove(prevName)
-                if(schema.swagger.required.contains(prevName)) {
+                if(schema.swagger.required?.contains(prevName) == true) {
                     schema.swagger.required.remove(prevName)
                     schema.swagger.required.add(newName)
                 }


### PR DESCRIPTION
Fix NPE when handling `required` property from `@Schema` annotation. Description of issue [here](https://github.com/SMILEY4/schema-kenerator/issues/61).