### PR TITLE
Type parameters for sealed interfaces

### DIFF
--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/DefaultSerializationTypeAnalyzerModule.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/DefaultSerializationTypeAnalyzerModule.kt
@@ -35,6 +35,12 @@ class DefaultSerializationTypeAnalyzerModule(
      */
     private val findTypeParametersUsingReflection: Boolean
 ) : SerializationTypeAnalyzerModule {
+    companion object {
+        private val DEFAULT_SERIAL_DESCRIPTOR_CLASSES = setOf(
+            "kotlinx.serialization.internal.PluginGeneratedSerialDescriptor",
+            "kotlinx.serialization.internal.InlineClassDescriptor",
+        )
+    }
 
     private val annotationAnalyzer = AnnotationAnalyzer()
 
@@ -466,7 +472,7 @@ class DefaultSerializationTypeAnalyzerModule(
      * Try to determine the type parameters of the given serial descriptor (if possible).
      */
     private fun extractTypeParameters(serialDescriptor: SerialDescriptor, type: KType?): List<SerialDescriptor> {
-        if (serialDescriptor::class.qualifiedName in setOf("kotlinx.serialization.internal.PluginGeneratedSerialDescriptor", "kotlinx.serialization.internal.InlineClassDescriptor")) {
+        if (serialDescriptor::class.qualifiedName in DEFAULT_SERIAL_DESCRIPTOR_CLASSES) {
             val property = serialDescriptor::class.memberProperties.find { it.name == "typeParameterDescriptors" }!!
             @Suppress("UNCHECKED_CAST") val typedProperty = property as KProperty1<SerialDescriptor, Array<SerialDescriptor>>
             typedProperty.isAccessible = true

--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/DefaultSerializationTypeAnalyzerModule.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/DefaultSerializationTypeAnalyzerModule.kt
@@ -466,7 +466,7 @@ class DefaultSerializationTypeAnalyzerModule(
      * Try to determine the type parameters of the given serial descriptor (if possible).
      */
     private fun extractTypeParameters(serialDescriptor: SerialDescriptor, type: KType?): List<SerialDescriptor> {
-        if (serialDescriptor::class.qualifiedName == "kotlinx.serialization.internal.PluginGeneratedSerialDescriptor") {
+        if (serialDescriptor::class.qualifiedName in setOf("kotlinx.serialization.internal.PluginGeneratedSerialDescriptor", "kotlinx.serialization.internal.InlineClassDescriptor")) {
             val property = serialDescriptor::class.memberProperties.find { it.name == "typeParameterDescriptors" }!!
             @Suppress("UNCHECKED_CAST") val typedProperty = property as KProperty1<SerialDescriptor, Array<SerialDescriptor>>
             typedProperty.isAccessible = true

--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/DefaultSerializationTypeAnalyzerModule.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/DefaultSerializationTypeAnalyzerModule.kt
@@ -22,8 +22,10 @@ import kotlinx.serialization.descriptors.SerialKind
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.descriptors.elementDescriptors
 import kotlinx.serialization.descriptors.elementNames
+import kotlinx.serialization.serializer
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
+import kotlin.reflect.KType
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.isAccessible
 
@@ -263,7 +265,7 @@ class DefaultSerializationTypeAnalyzerModule(
 
         // extract type parameters using reflection (if enabled)
         val typeParameters = if (findTypeParametersUsingReflection) {
-            extractTypeParameters(context.descriptor).mapIndexed { index, descriptor ->
+            extractTypeParameters(context.descriptor, context.type).mapIndexed { index, descriptor ->
                 val type = context.analyze(descriptor)
                 TypeParameterData(
                     name = "T$index",
@@ -337,7 +339,7 @@ class DefaultSerializationTypeAnalyzerModule(
 
         // extract type parameters using reflection (if enabled)
         val typeParameters = if (findTypeParametersUsingReflection) {
-            extractTypeParameters(context.descriptor).mapIndexed { index, descriptor ->
+            extractTypeParameters(context.descriptor, context.type).mapIndexed { index, descriptor ->
                 val type = context.analyze(descriptor)
                 TypeParameterData(
                     name = "T$index",
@@ -368,7 +370,7 @@ class DefaultSerializationTypeAnalyzerModule(
             id = context.id,
             identifyingName = identifyingName,
             descriptiveName = descriptiveName,
-            typeParameters = mutableListOf(),
+            typeParameters = typeParameters.toMutableList(),
             annotations = annotations,
             subtypes = subtypes.toMutableList(),
             supertypes = mutableListOf(),
@@ -463,12 +465,16 @@ class DefaultSerializationTypeAnalyzerModule(
     /**
      * Try to determine the type parameters of the given serial descriptor (if possible).
      */
-    private fun extractTypeParameters(serialDescriptor: SerialDescriptor): List<SerialDescriptor> {
+    private fun extractTypeParameters(serialDescriptor: SerialDescriptor, type: KType?): List<SerialDescriptor> {
         if (serialDescriptor::class.qualifiedName == "kotlinx.serialization.internal.PluginGeneratedSerialDescriptor") {
             val property = serialDescriptor::class.memberProperties.find { it.name == "typeParameterDescriptors" }!!
             @Suppress("UNCHECKED_CAST") val typedProperty = property as KProperty1<SerialDescriptor, Array<SerialDescriptor>>
             typedProperty.isAccessible = true
             return typedProperty.get(serialDescriptor).toList()
+        }
+        if (type != null) {
+            val parameters = type.arguments.map { it.type ?: error("") }
+            return parameters.map { serializer(it).descriptor }
         }
         return emptyList()
     }

--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzer.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzer.kt
@@ -3,6 +3,7 @@ package io.github.smiley4.schemakenerator.serialization.analyzer
 import io.github.smiley4.schemakenerator.core.data.TypeData
 import io.github.smiley4.schemakenerator.core.data.WrappedTypeData
 import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlin.reflect.KType
 
 /**
  * Analyzes the given type and returns the resulting [TypeData] (with additional nullability information)
@@ -12,11 +13,13 @@ interface SerializationTypeAnalyzer {
     /**
      * Analyzes the given descriptor and adds the results to the given collection
      * @param descriptor the input descriptor to parse
+     * @param type the original ktype reference the descriptor came from
      * @param knownTypeData the already known type data. Adds new results to this collection.
      * @param cache already processed descriptors with their type data. Adds new results to this map.
      */
     fun analyze(
         descriptor: SerialDescriptor,
+        type: KType?,
         knownTypeData: MutableList<TypeData>,
         cache: TypeDataCache
     ): WrappedTypeData

--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzerImpl.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzerImpl.kt
@@ -58,7 +58,7 @@ internal class SerializationTypeAnalyzerImpl(
 
     private fun analyze(input: KType, knownTypeData: MutableList<TypeData>): WrappedTypeData {
         return getSerializerFor(input)
-            ?.let { serializer -> analyze(serializer.descriptor, knownTypeData, TypeDataCache()) }
+            ?.let { serializer -> analyze(serializer.descriptor, input, knownTypeData, TypeDataCache()) }
             ?: WrappedTypeData(
                 typeData = knownTypeData.find(TypeId.createWildcard()) ?: TypeData.createWildcard().also { knownTypeData.add(it) },
                 nullable = false
@@ -66,11 +66,12 @@ internal class SerializationTypeAnalyzerImpl(
     }
 
     private fun analyze(input: SerialDescriptor, knownTypeData: MutableList<TypeData>): WrappedTypeData {
-        return analyze(input, knownTypeData, TypeDataCache())
+        return analyze(input, null, knownTypeData, TypeDataCache())
     }
 
     override fun analyze(
         descriptor: SerialDescriptor,
+        type: KType?,
         knownTypeData: MutableList<TypeData>,
         cache: TypeDataCache
     ): WrappedTypeData {
@@ -89,7 +90,7 @@ internal class SerializationTypeAnalyzerImpl(
         // check contextual descriptors
         val contextualByKClass = descriptor.capturedKClass?.let { serializersModule?.getContextual(it)?.descriptor }
         if (contextualByKClass != null) {
-            return analyze(contextualByKClass, knownTypeData, cache)
+            return analyze(contextualByKClass, null, knownTypeData, cache)
         }
 
         // input serial descriptor has already been parsed before (or is currently being parsed) -> break out of infinite loops
@@ -115,6 +116,7 @@ internal class SerializationTypeAnalyzerImpl(
                 analyzer = this,
                 id = reservedTypeId,
                 descriptor = descriptor,
+                type = type,
                 knownTypeData = knownTypeData,
                 cache = cache
             )

--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzerModule.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzerModule.kt
@@ -4,6 +4,7 @@ import io.github.smiley4.schemakenerator.core.data.TypeData
 import io.github.smiley4.schemakenerator.core.data.TypeId
 import io.github.smiley4.schemakenerator.core.data.WrappedTypeData
 import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlin.reflect.KType
 
 interface SerializationTypeAnalyzerModule {
 
@@ -11,6 +12,7 @@ interface SerializationTypeAnalyzerModule {
         private val analyzer: SerializationTypeAnalyzer,
         val id: TypeId,
         val descriptor: SerialDescriptor,
+        val type: KType?,
         val knownTypeData: MutableList<TypeData>,
         val cache: TypeDataCache
     ) {
@@ -18,6 +20,7 @@ interface SerializationTypeAnalyzerModule {
         fun analyze(descriptor: SerialDescriptor): WrappedTypeData {
             return this.analyzer.analyze(
                 descriptor = descriptor,
+                type = type,
                 knownTypeData = knownTypeData,
                 cache = cache,
             )

--- a/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzerModule.kt
+++ b/schema-kenerator-serialization/src/main/kotlin/io/github/smiley4/schemakenerator/serialization/analyzer/SerializationTypeAnalyzerModule.kt
@@ -20,7 +20,7 @@ interface SerializationTypeAnalyzerModule {
         fun analyze(descriptor: SerialDescriptor): WrappedTypeData {
             return this.analyzer.analyze(
                 descriptor = descriptor,
-                type = type,
+                type = null,
                 knownTypeData = knownTypeData,
                 cache = cache,
             )


### PR DESCRIPTION
Closes #67 

This PR supports type parameters for sealed classes in the `kotlinx.serialization` module by also keeping an (optional) `KType` reference along side the serial descriptor that is used to extract the type information.